### PR TITLE
Fix regressed font color issue on safari in ios light mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,9 +8,6 @@
   --breakpoint-xl: 1024px;
   --breakpoint-2xl: 2000px;
 
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-
   --color-purple: #200932;
   --color-purple-dark: #0d0216;
   --color-purple-light: #431e61;
@@ -40,20 +37,7 @@
   }
 }
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 
   /* circular background pattern */


### PR DESCRIPTION
Regression in safari on ios in light mode. The issue was introduced when migrating tailwind from v4 to v5.