### PR TITLE
Run playwright tests against localhost in GitHub Actions

### DIFF
--- a/.github/workflows/playwright-ci.yml
+++ b/.github/workflows/playwright-ci.yml
@@ -1,0 +1,68 @@
+name: Playwright Tests (CI)
+
+# Run against a local Docker container on PRs to main and post-merge pushes to main.
+# The existing playwright.yml (scheduled, against production) is unaffected.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  playwright-ci:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t solar-garlic-app:ci .
+
+      - name: Start app container
+        run: |
+          docker run -d \
+            --name nextjs-app \
+            -p 3000:3000 \
+            solar-garlic-app:ci
+
+      - name: Wait for app to be ready
+        run: |
+          echo "Waiting for app to start..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+              echo "App is ready after $i attempts"
+              exit 0
+            fi
+            echo "Attempt $i: not ready yet, waiting 5s..."
+            sleep 5
+          done
+          echo "App failed to start within 150s"
+          docker logs nextjs-app
+          exit 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          BASE_URL: http://localhost:3000
+          CI: true
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report-ci
+          path: playwright-report/
+          retention-days: 30
+
+      - name: Stop app container
+        if: always()
+        run: docker stop nextjs-app && docker rm nextjs-app || true

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/tests/about.spec.ts
+++ b/tests/about.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-const SITE_URL = 'https://solargarlicband.com'
-
 const PAGE = '/about'
 
 test('about page loads', async ({ page }) => {
-  const response = await page.goto(SITE_URL + PAGE, {
+  const response = await page.goto(PAGE, {
     waitUntil: 'networkidle',
   });
 

--- a/tests/contact.spec.ts
+++ b/tests/contact.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-const SITE_URL = 'https://solargarlicband.com'
-
 const PAGE = '/contact'
 
 test('contact page loads', async ({ page }) => {
-  const response = await page.goto(SITE_URL + PAGE, {
+  const response = await page.goto(PAGE, {
     waitUntil: 'networkidle',
   });
 

--- a/tests/events.spec.ts
+++ b/tests/events.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-const SITE_URL = 'https://solargarlicband.com'
-
 const PAGE = '/events'
 
 test('events page loads', async ({ page }) => {
-  const response = await page.goto(SITE_URL + PAGE, {
+  const response = await page.goto(PAGE, {
     waitUntil: 'networkidle',
   });
 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,9 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-const SITE_URL = 'https://solargarlicband.com'
-
 test('home page loads', async ({ page }) => {
-  const response = await page.goto(SITE_URL, {
+  const response = await page.goto('/', {
     waitUntil: 'networkidle',
   });
 

--- a/tests/music.spec.ts
+++ b/tests/music.spec.ts
@@ -1,11 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-const SITE_URL = 'https://solargarlicband.com'
-
 const PAGE = '/music'
 
 test('music page loads', async ({ page }) => {
-  const response = await page.goto(SITE_URL + PAGE, {
+  const response = await page.goto(PAGE, {
     waitUntil: 'networkidle',
   });
 


### PR DESCRIPTION
🐙 Cody here - 

Closes #29

## Summary
Adds a new CI workflow that runs Playwright tests against a locally-built Docker container on every PR to main and every post-merge push to main, so the tests validate feature-branch and merged code without hitting production.

The existing scheduled `playwright.yml` (which runs hourly against `https://solargarlicband.com`) is untouched.

## Changes
- **`.github/workflows/playwright-ci.yml`** — New workflow triggered on `pull_request` and `push` to `main`. Builds the Docker image from the Dockerfile, starts it on port 3000, waits up to 150 s for the app to be ready, then runs Playwright with `BASE_URL=http://localhost:3000`
- **`tests/*.spec.ts`** (about, contact, events, home, music) — Removed the hardcoded `SITE_URL = 'https://solargarlicband.com'` constant and switched to relative URL paths (e.g. `page.goto('/about')`). Playwright resolves these against `baseURL` from the config, which is already `process.env.BASE_URL || 'http://localhost:3000'`. This makes the tests target-agnostic: they hit production when the scheduled workflow sets `BASE_URL=https://solargarlicband.com`, and localhost when the new CI workflow sets `BASE_URL=http://localhost:3000`

## Testing
- The new workflow runs on every PR to main — GitHub Actions will execute it when this PR is opened
- The scheduled production tests continue unchanged; they set `BASE_URL=https://solargarlicband.com` which playwright passes as `baseURL`, so relative URLs resolve to the production host as before