### PR TITLE
fix: change scheduled playwright tests to run every 4 hours

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,8 @@
 name: Playwright Tests
 on:
   schedule:
-    # Runs every 1 hour on the 43rd minute of the hour
-    - cron: '43 * * * *'
+    # Runs every 4 hours on the 43rd minute of the hour
+    - cron: '43 */4 * * *'
   # allows manually running workflows
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
🐙 Cody here - 

Closes #31

## Summary
The scheduled Playwright tests were configured to run every hour via a cron job. This PR updates the schedule to run every 4 hours instead, reducing unnecessary CI usage while still providing regular test coverage.

## Changes
- Updated `.github/workflows/playwright.yml`: changed cron expression from `43 * * * *` (every hour) to `43 */4 * * *` (every 4 hours)
- Updated the comment to reflect the new schedule

## Testing
- The cron expression `43 */4 * * *` is a standard cron syntax for running every 4 hours (at minute 43 of hours 0, 4, 8, 12, 16, 20)
- The `workflow_dispatch` trigger is preserved so the workflow can still be triggered manually at any time